### PR TITLE
Catch exceptions coming from decrypt()

### DIFF
--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -33,12 +33,16 @@ defmodule Cipher do
     ```
   """
   def decrypt(crypted) when is_binary(crypted) do
-    res = crypted |> URI.decode_www_form |> Base.decode64
-    case res do
-      {:ok, decoded} ->
-        :crypto.block_decrypt(:aes_cbc128, @k, @i, decoded) |> depad
-      :error         ->
-        {:error, "Could not decode crypted string '#{crypted}'"}
+    try do
+      res = crypted |> URI.decode_www_form |> Base.decode64
+      case res do
+        {:ok, decoded} ->
+          :crypto.block_decrypt(:aes_cbc128, @k, @i, decoded) |> depad
+        :error         ->
+          {:error, "Could not decode crypted string '#{crypted}'"}
+      end      
+    rescue
+      e in ArgumentError -> {:error, e.message}
     end
   end
 


### PR DESCRIPTION
A nuber of exceptions may be thrown by various libraries used in decrypt.

One especially important one would be that URI.parse functions do not
validate a URI, and will raise errors if they get an invalid URI.

We should catch the error and provide a sensible return value to allow
the user to know that decrypt has failed and why.
