### PR TITLE
Require ivphrase >= 16 bytes

### DIFF
--- a/lib/cipher/digest.ex
+++ b/lib/cipher/digest.ex
@@ -8,6 +8,7 @@ defmodule Cipher.Digest do
   def generate_key(phrase), do: :crypto.hash(:sha, phrase) |> hexdigest |> String.slice(0,16)
 
   @doc "Generates a suitable iv for encryption based on given `phrase`"
+  def generate_iv(phrase) when byte_size(phrase) < 16, do: raise ArgumentError, message: "ivphrase must be at least 16 bytes long"
   def generate_iv(phrase), do: phrase |> String.slice(0,16)
 
   @doc "Gets an usable string from a binary crypto hash"


### PR DESCRIPTION
If the ivphrase is shorter than this, it triggers an ArgumentError from
`:crypto.block_encrypt/4`, which is confusing.

Checking the length at compile time prevents an apparently-successful
compilation that actually won't work, and will need to be fixed with
`mix deps.clean cipher && mix deps.compile cipher`
