### PR TITLE
add support for runtime phrase configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ When you decrypt non-valid strings you can get two kinds of errors:
 * `{:error, "Could not decode string 'yourstring'..."}` if your string was tampered or wrongly transferred.
 * `{:error, "Could not decrypt string 'yourstring'..."}` if your string was encrypted using different keys. Maybe some edge cases of tampering too.
 
+## Runtime Key Config
+* You may want to set your key configs from enviroment variables and not have those available at compile time.
+* Setting the runtime_phrases config to true will have Cipher grab the values from the config evertime instead of using the compiled values.
+```elixir
+config :cipher, runtime_phrases: true,
+                keyphrase: System.get_env("keyphrase"),
+                ivphrase: System.get_env("ivphrase")
+```
+
 ## Cipher/Parse JSON
 
 `cipher/1` and `parse/1`. Just as `encrypt/1` and `decrypt/1` but for JSON.

--- a/test/cipher_test.exs
+++ b/test/cipher_test.exs
@@ -137,4 +137,21 @@ defmodule CipherTest do
     assert {:ok, _} = C.validate_signed_url(s)
   end
 
+  test "will use runtime keys" do
+    original_keyphrase = H.env(:keyphrase)
+    original_ivphrase = H.env(:ivphrase)
+
+    # if we change runtime_phrases to true it will grab configs at runtime
+    # instead of compile time
+    Application.put_env(:cipher, :runtime_phrases, true)
+    Application.put_env(:cipher, :keyphrase, "testiekeyphraseforcipher_runtime")
+    Application.put_env(:cipher, :ivphrase, "testieivphraseforcipher_runtime")
+    assert "secret" |> C.encrypt  == "txp3eryk5R8zxQfUtz4htA%3D%3D"
+    assert "txp3eryk5R8zxQfUtz4htA%3D%3D" |> C.decrypt  == "secret"
+
+    # put things back to original values
+    Application.put_env(:cipher, :runtime_phrases, false)
+    Application.put_env(:cipher, :keyphrase, original_keyphrase)
+    Application.put_env(:cipher, :ivphrase, original_ivphrase)
+  end
 end


### PR DESCRIPTION
We are having problems because our secret phrases are not available on our CI build server. This was because of the elixir attributes compiling the config values.

We've added a config option to allow these values to be read at runtime, in our fork and wanted to see if your interested in these changes. 