### PR TITLE
Always use runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,6 @@ When you decrypt non-valid strings you can get two kinds of errors:
 * `{:error, "Could not decode string 'yourstring'..."}` if your string was tampered or wrongly transferred.
 * `{:error, "Could not decrypt string 'yourstring'..."}` if your string was encrypted using different keys. Maybe some edge cases of tampering too.
 
-## Runtime Key Config
-* You may want to set your key configs from enviroment variables and not have those available at compile time.
-* Setting the runtime_phrases config to true will have Cipher grab the values from the config evertime instead of using the compiled values.
-```elixir
-config :cipher, runtime_phrases: true,
-                keyphrase: System.get_env("keyphrase"),
-                ivphrase: System.get_env("ivphrase")
-```
-
 ## Cipher/Parse JSON
 
 `cipher/1` and `parse/1`. Just as `encrypt/1` and `decrypt/1` but for JSON.

--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -14,12 +14,8 @@ defmodule Cipher do
      "\n", :reset] |> IO.ANSI.format(true) |> IO.puts
   end
 
-  defp get_phrase(type) do
-    case type do
-      :keyphrase -> H.env(:keyphrase) |> Cipher.Digest.generate_key
-      :ivphrase -> H.env(:ivphrase) |> Cipher.Digest.generate_iv
-    end
-  end
+  defp get_phrase(:keyphrase), do: H.env(:keyphrase) |> Cipher.Digest.generate_key()
+  defp get_phrase(:ivphrase), do: H.env(:ivphrase) |> Cipher.Digest.generate_iv()
 
   @doc """
     Returns encrypted string containing given `data` string

--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -13,15 +13,11 @@ defmodule Cipher do
      "You need to configure both `keyphrase` and `ivphrase` to compile `Cipher`",
      "\n", :reset] |> IO.ANSI.format(true) |> IO.puts
   end
-  @k H.env(:keyphrase) |> Cipher.Digest.generate_key
-  @i H.env(:ivphrase) |> Cipher.Digest.generate_iv
 
   defp get_phrase(type) do
-    case {H.env(:runtime_phrases, false), type} do
-      {true, :keyphrase} -> H.env(:keyphrase) |> Cipher.Digest.generate_key
-      {false, :keyphrase} -> @k
-      {true, :ivphrase} -> H.env(:ivphrase) |> Cipher.Digest.generate_iv
-      {false, :ivphrase} -> @i
+    case type do
+      :keyphrase -> H.env(:keyphrase) |> Cipher.Digest.generate_key
+      :ivphrase -> H.env(:ivphrase) |> Cipher.Digest.generate_iv
     end
   end
 

--- a/test/cipher_test.exs
+++ b/test/cipher_test.exs
@@ -1,7 +1,7 @@
 require Cipher.Helpers, as: H  # the cool way
 
 defmodule CipherTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   alias Cipher, as: C
 
   test "the whole encrypt/decrypt stack" do
@@ -141,17 +141,15 @@ defmodule CipherTest do
     original_keyphrase = H.env(:keyphrase)
     original_ivphrase = H.env(:ivphrase)
 
-    # if we change runtime_phrases to true it will grab configs at runtime
-    # instead of compile time
-    Application.put_env(:cipher, :runtime_phrases, true)
     Application.put_env(:cipher, :keyphrase, "testiekeyphraseforcipher_runtime")
     Application.put_env(:cipher, :ivphrase, "testieivphraseforcipher_runtime")
+
+    on_exit fn ->
+      Application.put_env(:cipher, :keyphrase, original_keyphrase)
+      Application.put_env(:cipher, :ivphrase, original_ivphrase)
+    end
+
     assert "secret" |> C.encrypt  == "txp3eryk5R8zxQfUtz4htA%3D%3D"
     assert "txp3eryk5R8zxQfUtz4htA%3D%3D" |> C.decrypt  == "secret"
-
-    # put things back to original values
-    Application.put_env(:cipher, :runtime_phrases, false)
-    Application.put_env(:cipher, :keyphrase, original_keyphrase)
-    Application.put_env(:cipher, :ivphrase, original_ivphrase)
   end
 end


### PR DESCRIPTION
We're hitting an issue with compiling with Cipher because of how our runtime configuration system works.  We're essentially injecting passphrase and iv config at runtime by using a placeholder tuple in the config.  For example:
```
config :cipher, keyphrase: {:enviro, "encrypt_key"},
  ivphrase: {:enviro, "encrypt_iv"}
```
We're getting compile time errors on these lines because of the tuple:
```
@k H.env(:keyphrase) |> Cipher.Digest.generate_key
@i H.env(:ivphrase) |> Cipher.Digest.generate_iv
```

Is there a need to keep the compile-time eval?  I'm thinking we could just stick to runtime eval.  Doesn't seem like there would be any big performance hit or anything. 
