### PR TITLE
Make library compatible with OTP24

### DIFF
--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -312,31 +312,44 @@ defmodule Cipher do
       |> String.replace("%0a", "")
   end
 
-  # otp 23 deprecated and otp 24 removed retired cipher names
-  # http://erlang.org/doc/apps/crypto/new_api.html#retired-cipher-names
-  defp map_algorithm(:aes_cbc128, _key), do: :aes_128_cbc
-  defp map_algorithm(:aes_cbc256, _key), do: :aes_256_cbc
-  defp map_algorithm(:aes_gcm, key) do
-    case bit_size(key) do
-      128 -> :aes_128_gcm
-      192 -> :aes_192_gcm
-      256 -> :aes_256_gcm
+  # :crypto.crypto_one_time and :crypto.crypto_one_time_aead added in otp 22.0
+  # :crypto.block_encrypt and :crypto.block_decrypt deprecated in 23 and removed in 23
+  # http://erlang.org/doc/apps/crypto/new_api.html#the-new-api
+  if System.otp_release() |> String.to_integer() >= 23 do
+    # otp 23 deprecated and otp 24 removed retired cipher names
+    # http://erlang.org/doc/apps/crypto/new_api.html#retired-cipher-names
+    defp map_algorithm(:aes_cbc128, _key), do: :aes_128_cbc
+    defp map_algorithm(:aes_cbc256, _key), do: :aes_256_cbc
+    defp map_algorithm(:aes_gcm, key) do
+      case bit_size(key) do
+        128 -> :aes_128_gcm
+        192 -> :aes_192_gcm
+        256 -> :aes_256_gcm
+      end
     end
-  end
 
-  defp crypto_block_encrypt(algorithm, key, initialization_vector, {aad, plain_text}) do
-    :crypto.crypto_one_time_aead(map_algorithm(algorithm, key), key, initialization_vector, plain_text, aad, true)
-  end
+    defp crypto_block_encrypt(algorithm, key, initialization_vector, {aad, plain_text}) do
+      :crypto.crypto_one_time_aead(map_algorithm(algorithm, key), key, initialization_vector, plain_text, aad, true)
+    end
 
-  defp crypto_block_encrypt(algorithm, key, initialization_vector, plain_text) do
-    :crypto.crypto_one_time(map_algorithm(algorithm, key), key, initialization_vector, plain_text, true)
-  end
+    defp crypto_block_encrypt(algorithm, key, initialization_vector, plain_text) do
+      :crypto.crypto_one_time(map_algorithm(algorithm, key), key, initialization_vector, plain_text, true)
+    end
 
-  defp crypto_block_decrypt(algorithm, key, initialization_vector, {aad, data, tag}) do
-    :crypto.crypto_one_time_aead(map_algorithm(algorithm, key), key, initialization_vector, data, aad, tag, false)
-  end
+    defp crypto_block_decrypt(algorithm, key, initialization_vector, {aad, data, tag}) do
+      :crypto.crypto_one_time_aead(map_algorithm(algorithm, key), key, initialization_vector, data, aad, tag, false)
+    end
 
-  defp crypto_block_decrypt(algorithm, key, initialization_vector, data) do
-    :crypto.crypto_one_time(map_algorithm(algorithm, key), key, initialization_vector, data, false)
+    defp crypto_block_decrypt(algorithm, key, initialization_vector, data) do
+      :crypto.crypto_one_time(map_algorithm(algorithm, key), key, initialization_vector, data, false)
+    end
+  else
+    defp crypto_block_encrypt(algorithm, key, initialization_vector, encryption_payload) do
+      :crypto.block_encrypt(algorithm, key, initialization_vector, encryption_payload)
+    end
+
+    defp crypto_block_decrypt(algorithm, key, initialization_vector, cipher_data) do
+      :crypto.block_decrypt(algorithm, key, initialization_vector, cipher_data)
+    end
   end
 end

--- a/test/cipher_test.exs
+++ b/test/cipher_test.exs
@@ -5,7 +5,7 @@ defmodule CipherTest do
   alias Cipher, as: C
 
   test "the whole encrypt/decrypt stack" do
-    s = Poison.encode! %{"hola": " qué tal ｸｿ"}
+    s = Poison.encode! %{hola: " qué tal ｸｿ"}
     assert s == s |> C.encrypt |> C.decrypt
 
     assert {:error, _} = "random" |> C.decrypt    # decode fails
@@ -35,7 +35,7 @@ defmodule CipherTest do
   end
 
   test "get ciphered hash" do
-    h = %{"hola": " qué tal ｸｿ"}
+    h = %{hola: " qué tal ｸｿ"}
     s = h |> Poison.encode! |> C.encrypt
     assert C.cipher(h) == s
   end
@@ -68,14 +68,14 @@ defmodule CipherTest do
 
   test "Magic Token works with body" do
     url = "/bla/bla"
-    body = Poison.encode! %{"hola": " qué tal ｸｿ"}
+    body = Poison.encode! %{hola: " qué tal ｸｿ"}
     assert {:ok, _} = "#{url}?a=123&signature=#{H.env(:magic_token)}" |> C.validate_signed_body(body)
     assert {:error, _} = "#{url}?a=123&signature=#{H.env(:magic_token)}X" |> C.validate_signed_body(body)
   end
 
   test "validate_signed_body" do
     url = "/bla/bla"
-    body = Poison.encode! %{"hola": " qué tal ｸｿ"}
+    body = Poison.encode! %{hola: " qué tal ｸｿ"}
     assert {:error, _} = "#{url}" |> C.validate_signed_body(body)
     assert {:error, _} = "#{url}?signature=badhash" |> C.validate_signed_body(body)
     assert {:error, _} = "#{url}?asdkjh=sdfklh&signature=badhash" |> C.validate_signed_body(body)
@@ -84,7 +84,7 @@ defmodule CipherTest do
 
   test "signing body also denies params" do
     url = "/bla/bla"
-    body = Poison.encode! %{"hola": " qué tal ｸｿ"}
+    body = Poison.encode! %{hola: " qué tal ｸｿ"}
     signed = C.sign_url_from_body(url, body, deny: ["cb"])
     assert {:ok, _} = "#{signed}" |> C.validate_signed_body(body)
     assert {:ok, _} = "#{signed}&other=123456" |> C.validate_signed_body(body)
@@ -94,7 +94,7 @@ defmodule CipherTest do
 
   test "Magic Token works with signed mapped body" do
     url = "/bla/bla"
-    body = %{"hola": " qué tal ｸｿ"} |> Poison.encode! |> Poison.decode!
+    body = %{hola: " qué tal ｸｿ"} |> Poison.encode! |> Poison.decode!
     assert {:ok, _} = "#{url}?a=123&signature=#{H.env(:magic_token)}" |> C.validate_signed_body(body)
     assert {:error, _} = "#{url}?a=123&signature=#{H.env(:magic_token)}X" |> C.validate_signed_body(body)
   end
@@ -102,21 +102,21 @@ defmodule CipherTest do
   test "validate_signed_mapped_body" do
     url = "/bla/bla"
     # body is signed, then JSON encoded, then sent, then JSON decoded, then validated
-    raw_body = %{"hola": " qué tal ｸｿ", "ymás": "ymás"}
+    raw_body = %{hola: " qué tal ｸｿ", ymás: "ymás"}
     body = raw_body |> Poison.encode! |> Poison.decode!
     assert {:error, _} = "#{url}" |> C.validate_signed_body(body)
     assert {:error, _} = "#{url}?signature=badhash" |> C.validate_signed_body(body)
     assert {:error, _} = "#{url}?asdkjh=sdfklh&signature=badhash" |> C.validate_signed_body(body)
     assert {:ok, _} = "#{url}" |> C.sign_url_from_mapped_body(raw_body) |> C.validate_signed_body(body)
     # reordered works the same
-    raw_body = %{"ymás": "ymás", "hola": " qué tal ｸｿ"}
+    raw_body = %{ymás: "ymás", hola: " qué tal ｸｿ"}
     assert {:ok, _} = "#{url}" |> C.sign_url_from_mapped_body(raw_body) |> C.validate_signed_body(body)
   end
 
   test "signing mapped body also denies params" do
     url = "/bla/bla"
     # body is signed, then JSON encoded, then sent, then JSON decoded, then validated
-    raw_body = %{"hola": " qué tal ｸｿ"}
+    raw_body = %{hola: " qué tal ｸｿ"}
     body = raw_body |> Poison.encode! |> Poison.decode!
     signed = C.sign_url_from_mapped_body(url, raw_body, deny: ["cb"])
     assert {:ok, _} = "#{signed}" |> C.validate_signed_body(body)

--- a/test/validate_plug_test.exs
+++ b/test/validate_plug_test.exs
@@ -16,7 +16,7 @@ defmodule ValidatePlugTest do
   end
 
   test "validates POST/PUT requests" do
-    raw_body = %{"hola": " qué tal ｸｿ", "ymás": "ymás"}
+    raw_body = %{hola: " qué tal ｸｿ", ymás: "ymás"}
     encoded_body = raw_body |> Poison.encode!
 
     url = "/bogus"


### PR DESCRIPTION
In OTP24, :crypto.block_encrypt/4 and :crypto.block_decrypt/4 are removed. This PR is based on changes from this other [PR](https://github.com/ntrepid8/ex_crypto/pull/40/files) to make cipher work on OTP24.